### PR TITLE
Update variables.tf

### DIFF
--- a/openstack/sec_group/variables.tf
+++ b/openstack/sec_group/variables.tf
@@ -13,9 +13,11 @@ variable "protocol" {
 }
 
 variable "port_range_min" {
+  default = "1"
 }
 
 variable "port_range_max" {
+  default = "65535"
 }
 
 variable "remotes_ips_prefixes" {


### PR DESCRIPTION
queste due variabili sono obbligatorie, dovrei avere la possibilità di non inserirle poiché la variabile type protocol dipende dal port range